### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,11 +22,11 @@ export default {
   },
 
   // activate linter
-  activate: () => {
+  activate() {
     require('atom-package-deps').install('linter-icinga-validate');
   },
 
-  provideLinter: () => {
+  provideLinter() {
     return {
       name: 'Icinga',
       grammarScopes: ['source.icinga2'],


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.